### PR TITLE
fix: Tail Detection Emits Boundary Chunk Immediately

### DIFF
--- a/src/transformers/discard-epilogue.js
+++ b/src/transformers/discard-epilogue.js
@@ -18,7 +18,6 @@ async function* ketu(chunks) {
           if (chunk[0] === 0x2d) {
             remainingTail = 1;
           } else {
-            yield;
             yield chunk;
             remainingTail = undefined;
           }
@@ -27,7 +26,6 @@ async function* ketu(chunks) {
             foundTail = true;
             remainingTail = 0;
           } else {
-            yield;
             yield chunk;
             remainingTail = undefined;
           }
@@ -38,7 +36,6 @@ async function* ketu(chunks) {
           foundTail = true;
           remainingTail = 0;
         } else {
-          yield undefined;
           yield new Uint8Array([0x2d]);
           yield chunk;
           remainingTail = undefined;
@@ -49,9 +46,8 @@ async function* ketu(chunks) {
       default:
         if (!chunk) {
           remainingTail = 2;
-        } else {
-          yield chunk;
         }
+        yield chunk;
     }
     ({ value: chunk, done } = await chunks.next(foundTail));
   }

--- a/test/unit/transformers/discard-epilogue.test.js
+++ b/test/unit/transformers/discard-epilogue.test.js
@@ -58,7 +58,7 @@ describe.concurrent("Discard Epilogue", () => {
     for await (const part of ketu(chunks)) {
       output.push(part && textDecoder.decode(part));
     }
-    expect(output).toEqual([]);
+    expect(output).toEqual([,]);
   });
 
   it("should detect tail after and discard all subsequent chunks", async () => {
@@ -70,7 +70,7 @@ describe.concurrent("Discard Epilogue", () => {
     for await (const part of ketu(chunks)) {
       output.push(part && textDecoder.decode(part));
     }
-    expect(output).toEqual([]);
+    expect(output).toEqual([,]);
   });
 
   it("should detect a split tail", async () => {
@@ -83,7 +83,7 @@ describe.concurrent("Discard Epilogue", () => {
     for await (const part of ketu(chunks)) {
       output.push(part && textDecoder.decode(part));
     }
-    expect(output).toEqual([]);
+    expect(output).toEqual([,]);
   });
 
   it("should fail on a partial tail", async () => {


### PR DESCRIPTION
Tail detetion no longer holds on to the undefined "boundary" chunk while it waits to detect a tail in subsequent chunks; emits it immediately upon receiving it.

As a result of this fix, a part body is now available to be read as soon as the boundary is detected in the stream. Fixes #1.